### PR TITLE
57 recent searches should live within recent searches tab and only the 5 most recent searches should exist

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -150,13 +150,24 @@ function addToLocalStorage(searchValue) {
 // Should add a check to make sure that it's not currently in the local storage maybe? So we don't get multiple of the same search?
 function updateRecentSearches() {
   recentSearchesDropdown.innerHTML = "";
-  for (var i = 0; i < recentSearches.length; i++) {
+  var recentSearchesLimited = recentSearches.slice(0, 5);
+  for (var i = 0; i < recentSearchesLimited.length; i++) {
+    var listItem = document.createElement("a");
+    listItem.classList.add("dropdown-item");
+    listItem.textContent = recentSearchesLimited[i];
+    recentSearchesDropdown.appendChild(listItem);
+  }
+  var scrollableMenu = document.createElement("div");
+  scrollableMenu.classList.add("dropdown-content");
+  for (var i = 5; i < recentSearches.length; i++) {
     var listItem = document.createElement("a");
     listItem.classList.add("dropdown-item");
     listItem.textContent = recentSearches[i];
-    recentSearchesDropdown.appendChild(listItem);
+    scrollableMenu.appendChild(listItem);
   }
+  recentSearchesDropdown.appendChild(scrollableMenu);
 }
+
 
 
 // API GRABS

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -10,7 +10,7 @@
 
 var searchBar = document.querySelector(".search-bar");
 var submitButton = document.querySelector(".submit-btn");
-var recentSearchesDropdown = document.querySelector(".recent-searches");
+var recentSearchesDropdown = document.querySelector("#dropdown-menu2");
 var recentSearches = JSON.parse(localStorage.getItem("recentSearches")) || [];
 var countries = [
   "Japan",
@@ -167,6 +167,24 @@ function updateRecentSearches() {
   }
   recentSearchesDropdown.appendChild(scrollableMenu);
 }
+
+// get the dropdown trigger button and menu
+var dropdownTrigger = document.querySelector('.dropdown-trigger');
+var dropdownMenu = document.querySelector('.dropdown-menu');
+
+// add a click event listener to the dropdown trigger button
+dropdownTrigger.addEventListener('click', function() {
+  // toggle the "is-active" class on the dropdown menu
+  dropdownMenu.classList.toggle('is-active');
+});
+
+// add a click event listener to the document object
+document.addEventListener('click', function(event) {
+  // check if the target element is not the recent searches dropdown, the dropdown trigger button, or a child element of the recent searches dropdown
+  if (!event.target.closest('#dropdown-menu2') && event.target !== dropdownTrigger) {
+    dropdownMenu.classList.remove('is-active');
+  }
+});
 
 
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -5,12 +5,9 @@
 
 // FUNCTIONS
 
-// maybe not exactly right, but something like this
-// var countryName = searchBar.value;
-
 var searchBar = document.querySelector(".search-bar");
 var submitButton = document.querySelector(".submit-btn");
-var recentSearchesDropdown = document.querySelector("#dropdown-menu2");
+var recentSearchesDropdown = document.querySelector(".dropdown-trigger");
 var recentSearches = JSON.parse(localStorage.getItem("recentSearches")) || [];
 var countries = [
   "Japan",
@@ -49,20 +46,19 @@ function searchCountry(searchValue) {
 
   // adds new localStorage to dropDown
   updateRecentSearches();
-
 }
 var searchBar = document.querySelector(".search-bar");
 var countryList = document.getElementById("countryList");
 
 // // create datalist element with countries
-// for (var i = 0; i < countries.length; i++) {
-//   var option = document.createElement("option");
-//   option.value = countries[i];
-//   countryList.appendChild(option);
-// }
+for (var i = 0; i < countries.length; i++) {
+  var option = document.createElement("option");
+  option.value = countries[i];
+  countryList.appendChild(option);
+}
 
 // // set datalist to searchBar
-// searchBar.setAttribute("list", "countryList");
+searchBar.setAttribute("list", "countryList");
 
 // add event listener to search bar for input
 searchBar.addEventListener("input", function(event) {
@@ -149,42 +145,39 @@ function addToLocalStorage(searchValue) {
 // To eventually update dropdown for recentSearches – this is re-rendering all of them everytime this is called I think, which may be fine, especially if we are eventually limiting the number.
 // Should add a check to make sure that it's not currently in the local storage maybe? So we don't get multiple of the same search?
 function updateRecentSearches() {
-  recentSearchesDropdown.innerHTML = "";
+  var dropdownContent = document.querySelector('.dropdown-content');
+  dropdownContent.innerHTML = '';
   var recentSearchesLimited = recentSearches.slice(0, 5);
   for (var i = 0; i < recentSearchesLimited.length; i++) {
-    var listItem = document.createElement("a");
-    listItem.classList.add("dropdown-item");
-    listItem.textContent = recentSearchesLimited[i];
-    recentSearchesDropdown.appendChild(listItem);
+    var recentSearch = recentSearchesLimited[i];
+    var link = document.createElement('a');
+    link.classList.add('dropdown-item');
+    link.textContent = recentSearch;
+    dropdownContent.appendChild(link);
   }
-  var scrollableMenu = document.createElement("div");
-  scrollableMenu.classList.add("dropdown-content");
-  for (var i = 5; i < recentSearches.length; i++) {
-    var listItem = document.createElement("a");
-    listItem.classList.add("dropdown-item");
-    listItem.textContent = recentSearches[i];
-    scrollableMenu.appendChild(listItem);
-  }
-  recentSearchesDropdown.appendChild(scrollableMenu);
 }
 
-// get the dropdown trigger button and menu
-var dropdownTrigger = document.querySelector('.dropdown-trigger');
-var dropdownMenu = document.querySelector('.dropdown-menu');
-
-// add a click event listener to the dropdown trigger button
-dropdownTrigger.addEventListener('click', function() {
-  // toggle the "is-active" class on the dropdown menu
-  dropdownMenu.classList.toggle('is-active');
-});
-
-// add a click event listener to the document object
-document.addEventListener('click', function(event) {
-  // check if the target element is not the recent searches dropdown, the dropdown trigger button, or a child element of the recent searches dropdown
-  if (!event.target.closest('#dropdown-menu2') && event.target !== dropdownTrigger) {
-    dropdownMenu.classList.remove('is-active');
+document.addEventListener("click", function (event) {
+  var dropdownTrigger = document.querySelector(".dropdown-trigger");
+  var dropdownMenu = document.querySelector("#dropdown-trigger");
+  if (
+    !dropdownTrigger.contains(event.target) &&
+    !dropdownMenu.contains(event.target)
+  ) {
+    dropdownMenu.classList.remove("is-active");
   }
 });
+
+var dropdownItems = document.querySelectorAll(".dropdown-item");
+dropdownItems.forEach(function (item) {
+  item.addEventListener("click", function (event) {
+    dropdownMenu.classList.remove("is-active");
+  });
+});
+
+
+
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -61,9 +61,9 @@
             </div>
             <div class="dropdown-menu" id="dropdown-menu2" role="menu">
               <div class="dropdown-content">
-                <div class="dropdown-item">
-                  <p>Add buttons for recent searches from localStorage? <strong>-</strong>-</p>
-                </div>
+                <div class="dropdown-item"> Recent Searches</a>
+              
+                <!-- </div>
                 <hr class="dropdown-divider">
                 <div class="dropdown-item">
                   <p>Note: add a <code>&lt;div&gt;</code> with class="dropdown-item" if you want to add more items.</p>
@@ -71,7 +71,15 @@
                 <hr class="dropdown-divider">
                 <a href="#" class="dropdown-item">
                   This is a link in case we wanted to add one
-                </a>
+                </a> -->
+                <!-- Only show the 5 most recent searches in the dropdown -->
+                <a href="#" class="dropdown-item"></a>
+                <a href="#" class="dropdown-item"></a>
+                <a href="#" class="dropdown-item"></a>
+                <a href="#" class="dropdown-item"></a>
+                <a href="#" class="dropdown-item"></a>
+                <!-- Show the rest of the recent searches in a scrollable menu -->
+                <div class="dropdown-content"></div>
               </div>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -49,17 +49,17 @@
               </a>
             </div>
           </div>
-
-          <div class="dropdown is-active">
+<!-- I removed the class "is active" from the dropdown so it functions like a dropdown and isnt always active  -->
+          <div class="dropdown is-hoverable">
             <div class="dropdown-trigger">
-              <button class="button" aria-haspopup="true" aria-controls="dropdown-menu2">
+              <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
                 <span>Recent Searches</span>
                 <span class="icon is-small">
                   <i class="fas fa-angle-down" aria-hidden="true"></i>
                 </span>
               </button>
             </div>
-            <div class="dropdown-menu" id="dropdown-menu2" role="menu">
+            <div class="dropdown-menu" id="dropdown-menu" role="menu">
               <div class="dropdown-content">
                 <div class="dropdown-item"> Recent Searches</a>
               


### PR DESCRIPTION
I made some small changes to the HTML, for example we were using two types of dropdown menus/classes, of dropdown and dropdown2, it was causing conflicts and i was able to simplify it into one. Now the searches exist in the search bar and wont crowd your page up.